### PR TITLE
Adding nerd font icons support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -2,6 +2,7 @@ let assert = require("node:assert");
 let path = require("node:path");
 let { homedir } = require("node:os");
 let { window, workspace, commands, Uri, EventEmitter, FileType, Selection, languages, Range, Diagnostic, DiagnosticRelatedInformation, Location } = require("vscode");
+const { renderListing, iconsEnabled } = require("./icons");
 
 /**
  * The scheme is used to associate vsnetrw documents with the text content provider
@@ -161,6 +162,12 @@ function getLineUnderCursor() {
   let editor = window.activeTextEditor;
   assert(editor, "No active editor");
   let line = editor.document.lineAt(editor.selection.active);
+
+  if (iconsEnabled()) {
+    // remove icon from line
+    return line.text.substring(2)
+  }
+
   return line.text;
 }
 
@@ -415,7 +422,7 @@ async function provideTextDocumentContent(documentUri) {
   });
 
   let listings = results.map(([name, type]) => {
-    return type & FileType.Directory ? `${name}/` : name;
+    return renderListing(name, Boolean(type & FileType.Directory));
   });
 
   let hasParent = path.dirname(pathName) !== pathName;

--- a/icons.js
+++ b/icons.js
@@ -1,0 +1,130 @@
+const { workspace } = require("vscode");
+
+/**
+ * Mapping of file extension to icon
+ * @type {Object.<string, string>}
+ */
+const icons = {
+    // docs
+    'txt': '',
+    'doc': '',
+    'docx': '',
+    'pdf': '',
+    'xls': '',
+    'xlsx': '',
+    'ppt': '',
+    'pptx': '',
+    // images
+    'jpg': '',
+    'png': '',
+    'gif': '',
+    'svg': '󰜡',
+    // programming
+    'json': '',
+    'md': '',
+    'vscodeignore': '󰨞',
+    'gitignore': '',
+    'java': '',
+    'py': '',
+    'cpp': '󰌛',
+    'c': '󰙱',
+    'cs': '󰌛',
+    'php': '󰌟',
+    'html': '󰌝',
+    'css': '',
+    'rb': '',
+    'go': '󰟓',
+    'swift': '',
+    'rust': '',
+    'ts': '',
+    'js': '',
+    'jsx': '',
+    'tsx': '',
+    'sh': '',
+    'sql': '',
+    'lua': '󰢱',
+    'r': '󰟔',
+    'scala': '',
+    'kotlin': '',
+    'asm': '',
+    'dockerignore': '',
+    'yml': '',
+    'xml': '󰗀',
+    'ini': '',
+    'vue': '',
+    'coffee': '',
+    'groovy': '',
+    'gradle': '',
+    'dart': '',
+    'ejs': '',
+    'less': '',
+    'sass': '',
+    'scss': '',
+    'styl': '',
+    'zsh': '',
+    'bash': '',
+    'cmd': '',
+    'xaml': '',
+    'csproj': '',
+    'sln': '',
+    'vb': '',
+    'conf': '',
+    'toml': ''
+};
+
+/**
+ * Mapping of special files to icon
+ * @type {Object.<string, string>}
+ */
+const specialFilesIcons = {
+    'package.json': '',
+    'dockerfile': '',
+}
+
+/**
+ * Get icon for filename with extension
+ * @param {string} filename
+ */
+function getIconFile(filename) {
+    const extension = filename?.split('.')?.pop()?.toLowerCase();
+
+    if (extension && icons[extension]) {
+        return icons[extension];
+    }
+
+    return ''
+}
+
+function getIconDirectory() {
+    return ''
+}
+
+
+/**
+ * @param {string} filename 
+ * @param {boolean} isDirectory
+ * @returns 
+ */
+function renderListing(filename, isDirectory = false) {
+    if (iconsEnabled()) {
+        if (isDirectory) {
+            return `${getIconDirectory()} ${filename}/`
+        }
+
+        if (filename in specialFilesIcons) {
+            return `${specialFilesIcons[filename]} ${filename}`
+        }
+
+        return `${getIconFile(filename)} ${filename}`
+    }
+
+    return isDirectory ? `${filename}/` : filename
+}
+
+function iconsEnabled() {
+    return workspace.getConfiguration("vsnetrw").useNerdFontIcons
+}
+
+module.exports = {
+    renderListing, iconsEnabled
+}

--- a/package.json
+++ b/package.json
@@ -112,7 +112,19 @@
 				"editor.minimap.enabled": false,
 				"editor.renderWhitespace": "none"
 			}
-		}
+		},
+    "configuration": [
+      {
+        "title": "vsnetrw",
+        "properties": {
+          "vsnetrw.useNerdFontIcons": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable Nerd Font icons for files and directories. You should set a Nerd Font as the Font Family in VS Code"
+          }
+        }
+      }
+    ]
 	},
 	"devDependencies": {
 		"@types/mocha": "^9.1.1",


### PR DESCRIPTION
Hey 👋 

## Changes

- Added new `icons.js` with the mappings for the icons
- Added new configuration option to package.json
- Minimal changes to `extension.js` to enable the rendering of the icons

Regarding tests, I'm thinking:
- Confirm if the icons are being rendered if the option is enabled
- Run all the functionality tests for when the option is enabled? (making all the tests run twice)

Can you think about more scenarios you want to cover?

## Some screenshots
<img width="383" alt="image" src="https://github.com/danprince/vsnetrw/assets/1500881/af6c69f7-f689-4080-b99f-dcf7588ad773">
<img width="249" alt="image" src="https://github.com/danprince/vsnetrw/assets/1500881/feea4003-122f-49cb-adb7-22d84ca6c2a1">
<img width="1265" alt="image" src="https://github.com/danprince/vsnetrw/assets/1500881/7d36b0d5-63ba-410b-ab05-bf2d5d6418e4">
<img width="384" alt="image" src="https://github.com/danprince/vsnetrw/assets/1500881/00b42c2b-78bf-4059-b3de-203925f51bbc">

