### PR TITLE
Fix flash of plaintext doc

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -117,8 +117,8 @@ async function openExplorer(dirName) {
 
   let uri = createUri(dirName);
   let doc = await workspace.openTextDocument(uri);
-  await window.showTextDocument(doc, { preview: true });
   await languages.setTextDocumentLanguage(doc, languageId);
+  await window.showTextDocument(doc, { preview: true });
   moveCursorToPreviousFile();
 }
 


### PR DESCRIPTION
Think this was causing a subtle bug where the document would open as plaintext before switching its type to `"vsnetrw"`.

Reported in https://github.com/danprince/vsnetrw/issues/20 as seeing line numbers flash for a second before the extension specific settings were applied.